### PR TITLE
Fixed navbar annotation gets clipped

### DIFF
--- a/src/components/landing/ui/features-cards.tsx
+++ b/src/components/landing/ui/features-cards.tsx
@@ -430,7 +430,7 @@ export function FeatureCard4() {
                     initial={{ opacity: 0, x: -10 }}
                     animate={isHovered ? { opacity: 1, x: 0 } : { opacity: 0, x: -10 }}
                     transition={{ delay: 1.0, duration: 0.4 }}
-                    className="absolute top-1/2 right-1/2 translate-x-0 -translate-y-[150px] mr-[160px] md:mr-[180px] flex items-center justify-end"
+                    className="absolute left-[max(1rem,calc(50%_-_22.75rem))] top-1/2 -translate-y-[150px] flex items-center justify-start"
                 >
                     <div className="bg-background text-foreground text-xs font-bold px-3 py-1.5 rounded-lg shadow-xl border whitespace-nowrap">Navbar Component</div>
                     <svg width="40" height="2" className="overflow-visible mx-2">
@@ -443,7 +443,7 @@ export function FeatureCard4() {
                     initial={{ opacity: 0, x: 10 }}
                     animate={isHovered ? { opacity: 1, x: 0 } : { opacity: 0, x: 10 }}
                     transition={{ delay: 1.3, duration: 0.4 }}
-                    className="absolute top-1/2 left-1/2 -translate-y-[10px] ml-[160px] md:ml-[180px] flex items-center"
+                    className="absolute left-[min(calc(50%_+_11.25rem),calc(100%_-_11rem))] top-1/2 -translate-y-[10px] flex items-center"
                 >
                     <svg width="40" height="2" className="overflow-visible mx-2">
                         <line x1="40" y1="1" x2="0" y2="1" stroke="currentColor" strokeWidth="1.5" strokeDasharray="4 4" className="text-foreground/30" />


### PR DESCRIPTION
Fixes #40 
When clicking on the "Ship landing pages at lightspeed" card in the Open Source With Story section, the annotation label "Navbar Component" on the left side is partially hidden and clipped.

What i did is have shifted that navbar component text to left side with the line such that the text is visible and also when the screen size gets decreased the line keep coming on the left side such that the text is visible the same has been done to the "Hero block" text as that was also not visible if the screen size decreases. Now both the texts are visible in any screen size

Before 

https://github.com/user-attachments/assets/4bcca40b-1a8b-47b3-934e-3e983c80f013

After 

https://github.com/user-attachments/assets/8fa62d32-4c11-4b59-bb36-0b81c6c51fbe

## Summary by Sourcery

Adjust annotation label positioning in the feature card to prevent clipping at various screen sizes.

Bug Fixes:
- Ensure the "Navbar Component" annotation label is fully visible and no longer clipped on smaller viewports.
- Keep the "Hero block" annotation label within bounds across responsive breakpoints by adjusting its horizontal positioning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the hover animation layout for a landing page feature card so the animated elements position more consistently across screen sizes.
  * Adjusted alignment and spacing behavior to keep the effect anchored correctly on the left side.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->