### PR TITLE
fix: make theme button work on first click for new users

### DIFF
--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -8,7 +8,14 @@ import { Button } from '@/components/ui/button'
 
 export const ThemeToggle = () => {
     const [mounted, setMounted] = React.useState(false)
-    const { theme, setTheme } = useTheme()
+    const { theme, setTheme, systemTheme } = useTheme()
+
+    const getTheme = () => {
+        if (theme === 'system') {
+            return systemTheme;
+        }
+        return theme;
+    }
 
     React.useEffect(() => {
         setMounted(true)
@@ -27,11 +34,11 @@ export const ThemeToggle = () => {
 
     return (
         <Button
-            onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+            onClick={() => setTheme(getTheme() === 'dark' ? 'light' : 'dark')}
             variant="ghost"
             aria-label="toggle theme"
             className="size-8 rounded-full">
-            {theme === 'dark' ? <SunDim className="size-5!" /> : <MoonStar />}
+            {getTheme() === 'dark' ? <SunDim className="size-5!" /> : <MoonStar />}
         </Button>
     )
 }


### PR DESCRIPTION
- Resolves the theme toggle issue for first-time users.
- Uses the resolved system theme correctly on initial render.
- Ensures the button works properly on the first click.
- Keeps the theme icon state in sync with the active theme.

- fixes #44

## Summary by Sourcery

Fix theme toggle behavior to respect resolved system theme and work correctly on initial render for new users.

Bug Fixes:
- Resolve theme toggle not working on first click for first-time users by basing the toggle on the effective theme instead of the raw setting.
- Keep the theme toggle icon state in sync with the currently active (including system-resolved) theme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the theme toggle so it correctly recognizes and reflects the active system theme.
  * Updated the displayed icon and toggle behavior to match the actual current theme when the app is set to use system settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->