### PR TITLE
fix: Change items key from label to title

### DIFF
--- a/src/lib/component-docs.ts
+++ b/src/lib/component-docs.ts
@@ -761,8 +761,8 @@ export function GlassDockDemo() {
   return (
     <GlassDock
       items={[
-        { icon: "home", label: "Home", href: "/" },
-        { icon: "settings", label: "Settings", href: "/settings" },
+        { icon: "home", title: "Home", href: "/" },
+        { icon: "settings", title: "Settings", href: "/settings" },
       ]}
     />
   )


### PR DESCRIPTION
The current usage documentation for the Glass Dock uses label to represent a DockItem but the DockItem interface in the GlassDock component uses title.

## Summary by Sourcery

Bug Fixes:
- Correct the GlassDock demo items to use the title key expected by DockItem instead of the incorrect label key in documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the GlassDock usage example to use the correct `title` property for Home and Settings dock items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->