### PR TITLE
fix: prevent component descriptions overflowing

### DIFF
--- a/src/app/components/layout.tsx
+++ b/src/app/components/layout.tsx
@@ -1,5 +1,4 @@
 import { Sidebar } from "@/components/layout/sidebar";
-import { AlignLeft } from "lucide-react";
 import { TableOfContents } from "@/components/layout/toc";
 export default function ComponentsLayout({
   children,
@@ -32,7 +31,7 @@ export default function ComponentsLayout({
         />
       </div>
 
-      <main className="relative py-3 lg:py-4 pr-2 md:pr-4 md:pl-8 lg:pl-12 xl:pl-20">
+      <main className="relative min-w-0 py-3 lg:py-4 pr-2 md:pr-4 md:pl-8 lg:pl-12 xl:pl-20">
         <div className="w-full min-w-0 [&>div]:max-w-6xl">
           {children}
         </div>

--- a/src/app/components/page.tsx
+++ b/src/app/components/page.tsx
@@ -101,7 +101,7 @@ export default function ComponentsIndexPage() {
             <div
               key={category.name}
               className={cn(
-                "border-r border-t border-border/70 bg-card p-5 first:border-t-0 md:[&:nth-child(2)]:border-t-0 xl:[&:nth-child(3)]:border-t-0",
+                "min-w-0 border-r border-t border-border/70 bg-card p-5 first:border-t-0 md:[&:nth-child(2)]:border-t-0 xl:[&:nth-child(3)]:border-t-0",
                 "md:[&:nth-child(2n)]:border-r-0 xl:[&:nth-child(2n)]:border-r xl:[&:nth-child(3n)]:border-r-0",
               )}
             >
@@ -127,10 +127,10 @@ export default function ComponentsIndexPage() {
                   <Link
                     key={item.slug}
                     href={`/components/${item.slug}`}
-                    className="group border border-transparent px-3 py-2 transition-colors hover:border-border hover:bg-muted/40"
+                    className="group block min-w-0 border border-transparent px-3 py-2 transition-colors hover:border-border hover:bg-muted/40"
                   >
-                    <span className="flex items-center justify-between gap-3">
-                      <span className="min-w-0">
+                    <span className="flex min-w-0 items-center justify-between gap-3">
+                      <span className="min-w-0 flex-1">
                         <span className="block truncate text-sm font-medium group-hover:text-foreground">{item.name}</span>
                         <span className="mt-0.5 block truncate text-xs text-muted-foreground">{item.description}</span>
                       </span>


### PR DESCRIPTION
## What changed

This fixes a layout issue on the `/components` page where longer component descriptions could overflow out of the catalog column and run underneath the "On this page" sidebar.

The fix adds `min-w-0` constraints to the components layout and catalog item wrappers so the existing truncated text behavior works inside the available column width.

## Why

Some descriptions in the Interactive section are longer than the available space. Instead of clipping inside the card, they stretched the content area and visually overlapped the right sidebar.

## Screenshots

Before:

<img width="1736" height="1100" alt="Screenshot 2026-07-17 at 6 39 00 PM" src="https://github.com/user-attachments/assets/0b520d24-8717-4365-bd1f-5cfeabc94c79" />

After:

<img width="1745" height="1040" alt="Screenshot 2026-07-17 at 6 39 31 PM" src="https://github.com/user-attachments/assets/61a48e64-c103-462b-ac78-1e5611370b04" />

## Testing

- Ran `npx eslint src/app/components/page.tsx src/app/components/layout.tsx`
- Ran `npm run build`

## Summary by Sourcery

Fix layout constraints on the components catalog page to prevent long descriptions from overflowing into the sidebar.

Bug Fixes:
- Prevent long component descriptions on the /components page from stretching the catalog column and overlapping the sidebar.

Enhancements:
- Constrain component catalog items and main content area with min-w-0 to ensure text truncation respects the available column width.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout behavior for component catalog cards and links, ensuring long text truncates more reliably without causing overflow.
  * Preserved existing hover states, spacing, and navigation interactions while improving responsive width handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->