### PR TITLE
fix: update copy code button visual on light mode modified

### DIFF
--- a/src/components/ui/copy-button.tsx
+++ b/src/components/ui/copy-button.tsx
@@ -18,7 +18,7 @@ export function CopyButton({ code, className }: { code: string; className?: stri
   return (
     <button
       className={cn(
-        "relative z-10 flex h-7 w-7 items-center justify-center rounded-md border bg-zinc-900 border-zinc-800 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-50 transition-colors",
+        "relative z-10 flex h-7 w-7 items-center justify-center rounded-md border bg-zinc-900 border-zinc-800 text-zinc-400 hover:text-neutral-700 hover:bg-zinc-800 dark:hover:text-zinc-50 transition-colors",
         className
       )}
       onClick={() => {


### PR DESCRIPTION
https://github.com/user-attachments/assets/9d1a0bed-1c51-4f70-8722-30eb54eba746

I added a hover state text color similar to the full screen button next to the copy code button and updated the existing hover state to dark mode.

## Summary by Sourcery

Enhancements:
- Update copy button hover text color to match adjacent controls in light mode while preserving appropriate contrast in dark mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the copy button’s hover colors for improved visual consistency.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->