### PR TITLE
fix: correct spelling of Vengeance in features section heading

### DIFF
--- a/src/components/landing/features.tsx
+++ b/src/components/landing/features.tsx
@@ -9,7 +9,7 @@ export default function Features() {
         <Container>
             <div className="md:border-x border-b overflow-hidden">
                 <div className="flex-1 flex flex-col gap-4 md:gap-8 justify-center px-4 md:px-8 py-8 md:py-16 lg:py-24">
-                    <Heading variant="big" className="text-center">Why Vengence?</Heading>
+                    <Heading variant="big" className="text-center">Why Vengeance?</Heading>
                     <SubHeading variant="big" className="text-center mx-auto w-full max-w-2xl">
                         Vengeance UI is built to explore unique interaction patterns from displacement hover effects to animated tooltips and scroll-driven components.
                     </SubHeading>


### PR DESCRIPTION
This pull request makes a minor correction to the `Features` component. The main change is a typo fix in the heading text.

- Fixed a typo in the main heading from "Why Vengence?" to "Why Vengeance?" in `features.tsx`.

Before:

<img width="1496" height="670" alt="image" src="https://github.com/user-attachments/assets/1c32221e-4b00-4094-85ba-1b36e58b43a5" />

After:

<img width="1494" height="682" alt="image" src="https://github.com/user-attachments/assets/8bfae97c-d74f-4bd6-8748-1e2191a25345" />

## Summary by Sourcery

Bug Fixes:
- Fix a typo in the landing page features heading from "Why Vengence?" to "Why Vengeance?".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the landing page heading spelling from “Why Vengence?” to “Why Vengeance?”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->