### PR TITLE
Add Stats Counter component

### DIFF
--- a/public/r/registry.json
+++ b/public/r/registry.json
@@ -1039,6 +1039,16 @@
     ]
   },
   {
+    "name": "stats-counter",
+    "dependencies": [
+      "framer-motion"
+    ],
+    "type": "registry:ui",
+    "files": [
+      "public/r/stats-counter.json"
+    ]
+  },
+  {
     "name": "staggered-grid",
     "dependencies": [
       "gsap"

--- a/public/r/stats-counter.json
+++ b/public/r/stats-counter.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "stats-counter",
+  "type": "registry:ui",
+  "dependencies": [
+    "framer-motion"
+  ],
+  "files": [
+    {
+      "path": "components/ui/stats-counter.tsx",
+      "content": "\"use client\";\n\nimport { useEffect, useRef, useState } from \"react\";\nimport { useInView, useMotionValue, useSpring } from \"framer-motion\";\nimport { cn } from \"@/lib/utils\";\n\ninterface StatsCounterProps {\n  value: number;\n  duration?: number;\n  prefix?: string;\n  suffix?: string;\n  decimals?: number;\n  className?: string;\n}\n\nexport default function StatsCounter({\n  value,\n  duration = 1.5,\n  prefix = \"\",\n  suffix = \"\",\n  decimals = 0,\n  className,\n}: StatsCounterProps) {\n  const ref = useRef<HTMLSpanElement>(null);\n  const isInView = useInView(ref, { once: true, margin: \"-100px\" });\n  const motionValue = useMotionValue(0);\n  const springValue = useSpring(motionValue, { duration: duration * 1000, bounce: 0 });\n  const [displayValue, setDisplayValue] = useState(0);\n\n  useEffect(() => {\n    if (isInView) {\n      motionValue.set(value);\n    }\n  }, [isInView, value, motionValue]);\n\n  useEffect(() => {\n    const unsubscribe = springValue.on(\"change\", (latest) => {\n      setDisplayValue(latest);\n    });\n    return unsubscribe;\n  }, [springValue]);\n\n  return (\n    <span ref={ref} className={cn(\"tabular-nums\", className)}>\n      {prefix}\n      {displayValue.toFixed(decimals)}\n      {suffix}\n    </span>\n  );\n}\n",
+      "type": "registry:ui",
+      "target": "components/ui/stats-counter.tsx"
+    }
+  ]
+}

--- a/src/components/docs/demo-renderer.tsx
+++ b/src/components/docs/demo-renderer.tsx
@@ -30,6 +30,7 @@ const DEMO_COMPONENTS: Record<string, React.ComponentType> = {
 
   "animated-rays": dynamic(() => import("@/components/docs/animated-rays").then((m) => ({ default: m.AnimatedRaysDemo })), { ssr: false, loading: LOADING }),
   "animated-number": dynamic(() => import("@/components/docs/animated-number").then((m) => ({ default: m.AnimatedNumberDemo })), { ssr: false, loading: LOADING }),
+  "stats-counter": dynamic(() => import("@/components/docs/stats-counter-demo").then((m) => ({ default: m.StatsCounterDemo })), { ssr: false, loading: LOADING }),
   "flip-text": dynamic(() => import("@/components/docs/Fliptext-examples/flip-text-demo").then((m) => ({ default: m.default })), { ssr: false, loading: LOADING }),
   "flip-fade-text": dynamic(() => import("@/components/docs/flip-fade-text").then((m) => ({ default: m.FlipFadeTextDemo })), { ssr: false, loading: LOADING }),
   "morph-text": dynamic(() => import("@/components/docs/morph-text-demo").then((m) => ({ default: m.MorphTextDemo })), { ssr: false, loading: LOADING }),

--- a/src/components/docs/stats-counter-demo.tsx
+++ b/src/components/docs/stats-counter-demo.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import StatsCounter from "@/components/ui/stats-counter";
+
+const stats = [
+  { value: 250, suffix: "+", label: "Components" },
+  { value: 12000, suffix: "+", label: "Downloads" },
+  { value: 99, suffix: "%", label: "Satisfaction" },
+];
+
+export function StatsCounterDemo() {
+  return (
+    <div className="grid grid-cols-3 gap-6 py-6 px-4 w-full max-w-md">
+      {stats.map((stat) => (
+        <div key={stat.label} className="flex flex-col items-center gap-1">
+          <div className="text-3xl md:text-4xl font-bold text-white">
+            <StatsCounter value={stat.value} suffix={stat.suffix} duration={2} />
+          </div>
+          <span className="text-xs text-zinc-400 text-center">{stat.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/stats-counter.tsx
+++ b/src/components/ui/stats-counter.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useInView, useMotionValue, useSpring } from "framer-motion";
+import { cn } from "@/lib/utils";
+
+interface StatsCounterProps {
+  value: number;
+  duration?: number;
+  prefix?: string;
+  suffix?: string;
+  decimals?: number;
+  className?: string;
+}
+
+export default function StatsCounter({
+  value,
+  duration = 1.5,
+  prefix = "",
+  suffix = "",
+  decimals = 0,
+  className,
+}: StatsCounterProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const isInView = useInView(ref, { once: true, margin: "-100px" });
+  const motionValue = useMotionValue(0);
+  const springValue = useSpring(motionValue, { duration: duration * 1000, bounce: 0 });
+  const [displayValue, setDisplayValue] = useState(0);
+
+  useEffect(() => {
+    if (isInView) {
+      motionValue.set(value);
+    }
+  }, [isInView, value, motionValue]);
+
+  useEffect(() => {
+    const unsubscribe = springValue.on("change", (latest) => {
+      setDisplayValue(latest);
+    });
+    return unsubscribe;
+  }, [springValue]);
+
+  return (
+    <span ref={ref} className={cn("tabular-nums", className)}>
+      {prefix}
+      {displayValue.toFixed(decimals)}
+      {suffix}
+    </span>
+  );
+}

--- a/src/lib/component-docs.ts
+++ b/src/lib/component-docs.ts
@@ -56,6 +56,30 @@ export function AnimatedButtonDemo() {
     ],
   },
 
+  "stats-counter": {
+    dependencies: "npm install framer-motion clsx tailwind-merge",
+    includeUtils: true,
+    usageCode: `import StatsCounter from "@/components/ui/stats-counter"
+
+export function StatsCounterDemo() {
+  return (
+    <StatsCounter
+      value={12000}
+      suffix="+"
+      duration={2}
+    />
+  )
+}`,
+    props: [
+      { prop: "value", type: "number", defaultValue: "-", description: "The target number to count up to." },
+      { prop: "duration", type: "number", defaultValue: "1.5", description: "Duration of the count-up animation in seconds." },
+      { prop: "prefix", type: "string", defaultValue: "''", description: "Text shown before the number (e.g. '$')." },
+      { prop: "suffix", type: "string", defaultValue: "''", description: "Text shown after the number (e.g. '+', '%')." },
+      { prop: "decimals", type: "number", defaultValue: "0", description: "Number of decimal places to display." },
+      { prop: "className", type: "string", defaultValue: "-", description: "Additional CSS classes to apply." },
+    ],
+  },
+
   "animated-rays": {
     dependencies: "npm install framer-motion clsx tailwind-merge",
     includeUtils: true,

--- a/src/lib/components-catalog.ts
+++ b/src/lib/components-catalog.ts
@@ -41,6 +41,7 @@ export const COMPONENT_CATEGORIES: ComponentCategory[] = [
     icon: Type,
     items: [
       { name: "Animated Number", slug: "animated-number", description: "Smooth numeric transitions", componentName: "animated-number" },
+      { name: "Stats Counter", slug: "stats-counter", description: "Count-up number animation triggered on scroll", componentName: "stats-counter", isNew: true },
       { name: "Flip Text", slug: "flip-text", description: "Character flip text animation", componentName: "flip-text" },
       { name: "Flip Fade Text", slug: "flip-fade-text", description: "Word flip and fade cycle", componentName: "flip-fade-text" },
       { name: "Liquid Text", slug: "liquid-text", description: "Fluid displacement text effect", componentName: "liquid-text" },


### PR DESCRIPTION
Adds a Stats Counter component. It shows a number that counts up when it scrolls into view, useful for things like download counts or other metrics on a landing page.

Requested in issue #1 (Animated Stats Counter).

What's included:
- the component itself (src/components/ui/stats-counter.tsx)
- a demo used on the docs page
- catalog and docs entries so it shows up in the sidebar and has install instructions
- the registry json file so it can be installed with the CLI

Tested locally: ran the dev server, opened /components/stats-counter, checked lint.

## Summary by Sourcery

Add a scroll-triggered stats counter component and wire it into the docs and component registry.

New Features:
- Introduce a StatsCounter UI component that animates numeric values when it enters the viewport, with configurable prefix, suffix, decimals, and duration.
- Add a StatsCounter demo page showcasing multiple metric counters for documentation.
- Register the StatsCounter in the components catalog and registry, including docs metadata and installation instructions.

Documentation:
- Document the StatsCounter component props, usage example, and dependency installation in the component docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Stats Counter component with animated numeric values triggered on viewport entry.
  * Supports prefixes, suffixes, decimal precision, animation duration, and custom styling.
  * Added a responsive demo showcasing component, download, and satisfaction metrics.
  * Added documentation, usage examples, and catalog listing for the new component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->