### PR TITLE
fix(ui): restore Liquid Text preview

### DIFF
--- a/src/components/docs/liquid-text.tsx
+++ b/src/components/docs/liquid-text.tsx
@@ -5,7 +5,7 @@ import { LiquidText } from "@/components/ui/liquid-text";
 export function LiquidTextDemo() {
     return (
         <div className="relative flex h-full w-full items-center justify-center overflow-hidden">
-            <LiquidText text="Hover Me" fontSize={220} className="h-full" />
+            <LiquidText text="Hover Me" fontSize={220} />
         </div>
     );
 }
@@ -13,7 +13,7 @@ export function LiquidTextDemo() {
 export function LiquidTextColorDemo() {
     return (
         <div className="relative flex h-full w-full items-center justify-center overflow-hidden">
-            <LiquidText text="Colorful" color="#ff6b6b" fontSize={180} className="h-full" />
+            <LiquidText text="Colorful" color="#ff6b6b" fontSize={180} />
         </div>
     );
 }
@@ -21,7 +21,7 @@ export function LiquidTextColorDemo() {
 export function LiquidTextThemeDemo() {
     return (
         <div className="relative flex h-full w-full items-center justify-center overflow-hidden">
-            <LiquidText text="Theme" lightColor="#1a1a1a" darkColor="#f5f5f5" fontSize={180} className="h-full" />
+            <LiquidText text="Theme" lightColor="#1a1a1a" darkColor="#f5f5f5" fontSize={180} />
         </div>
     );
 }
@@ -29,7 +29,7 @@ export function LiquidTextThemeDemo() {
 export function LiquidTextFontDemo() {
     return (
         <div className="relative flex h-full w-full items-center justify-center overflow-hidden">
-            <LiquidText text="Fancy" font="Georgia, serif" fontSize={200} className="h-full" />
+            <LiquidText text="Fancy" font="Georgia, serif" fontSize={200} />
         </div>
     );
 }


### PR DESCRIPTION
## Summary

Fix the blank Liquid Text preview on the [Liquid Text component page](https://www.vengenceui.com/components/liquid-text) by removing the `h-full` overrides from its demos.

**Affected page:** https://www.vengenceui.com/components/liquid-text

## Root cause

`LiquidText` has a built-in height of `600px`, but each demo replaced it with `h-full`.

`h-full` only works when the parent has a directly resolvable height. In this preview layout, it did not, so the LiquidText container collapsed to zero height.

The component converts a zero measurement to `1`, causing Three.js to create a canvas that was approximately `756px` wide but only `1px` tall. The text was rendering inside that canvas, but there was not enough height to see it.

Removing `h-full` lets LiquidText use its built-in `600px` height again.

## Screenshots

### Before

<img width="1037" height="753" alt="Screenshot 2026-08-16 at 02 05 10" src="https://github.com/user-attachments/assets/e0bd1867-b83f-4ff7-afcd-0cbae36062d0" />


### After

<img width="1022" height="740" alt="Screenshot 2026-08-16 at 02 06 40" src="https://github.com/user-attachments/assets/31c2c09e-01c1-49dc-8446-f64c214e3057" />


## Verification

- Text is visible when the preview loads
- The canvas retains its intended height
- Pointer displacement still works

No component implementation or public API changes.

## Summary by Sourcery

Bug Fixes:
- Fix collapsed LiquidText demo canvases by relying on the component’s built-in height instead of forcing full-height via CSS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated LiquidText demos by removing an unnecessary height styling property.
  * Text appearance, styling, and font configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->