### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,19 +127,19 @@ It is made for developers who want to move fast without compromising design.
 
 ## Star History
 
-<a href="https://star-history.com/#Ashutoshx7/VengeanceUI&Date">
+<a href="https://star-history.dera.page/#Ashutoshx7/VengeanceUI&Date">
   <picture>
     <source
       media="(prefers-color-scheme: dark)"
-      srcset="https://api.star-history.com/svg?repos=Ashutoshx7/VengeanceUI&type=Date&theme=dark&legend=top-left"
+      srcset="https://star-history.dera.page/svg?repos=Ashutoshx7/VengeanceUI&type=Date&theme=dark&legend=top-left"
     />
     <source
       media="(prefers-color-scheme: light)"
-      srcset="https://api.star-history.com/svg?repos=Ashutoshx7/VengeanceUI&type=Date&legend=top-left"
+      srcset="https://star-history.dera.page/svg?repos=Ashutoshx7/VengeanceUI&type=Date&legend=top-left"
     />
     <img
       alt="Star History Chart"
-      src="https://api.star-history.com/svg?repos=Ashutoshx7/VengeanceUI&type=Date&legend=top-left"
+      src="https://star-history.dera.page/svg?repos=Ashutoshx7/VengeanceUI&type=Date&legend=top-left"
     />
   </picture>
 </a>


### PR DESCRIPTION
The current star history chart is broken because of GitHub stargazer API restrictions. This switches the chart to star-history.dera.page, which uses an alternative data source that needs no API token, so the chart renders correctly again.

## Summary by Sourcery

Documentation:
- Refresh the README star history chart links and image sources to point to the new star-history.dera.page data source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History link and chart image URLs to use the new hosting domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->