### PR TITLE
fix(docs): align StackedLogos usage with logoGroups API

### DIFF
--- a/packages/mcp/data/index.json
+++ b/packages/mcp/data/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-17T12:26:29.941Z",
+  "generatedAt": "2026-08-20T21:34:05.621Z",
   "registryBaseUrl": "https://www.vengenceui.com/r",
   "categories": [
     {
@@ -3235,13 +3235,13 @@
       "dependencies": "npm install clsx tailwind-merge",
       "includeUtils": true,
       "manualNotes": null,
-      "usageCode": "import { StackedLogos } from \"@/components/ui/stacked-logos\"\n\nexport function StackedLogosDemo() {\n  return (\n    <StackedLogos\n      logos={[\n        { src: \"/logo1.svg\", alt: \"Logo 1\" },\n        { src: \"/logo2.svg\", alt: \"Logo 2\" },\n      ]}\n    />\n  )\n}",
+      "usageCode": "import { StackedLogos } from \"@/components/ui/stacked-logos\"\n\nconst logoGroups = [\n  [\n    <img key=\"acme\" src=\"/logos/acme.svg\" alt=\"Acme\" />,\n    <img key=\"globex\" src=\"/logos/globex.svg\" alt=\"Globex\" />,\n  ],\n  [\n    <img key=\"initech\" src=\"/logos/initech.svg\" alt=\"Initech\" />,\n    <img key=\"umbrella\" src=\"/logos/umbrella.svg\" alt=\"Umbrella\" />,\n  ],\n]\n\nexport function StackedLogosDemo() {\n  return <StackedLogos logoGroups={logoGroups} />\n}",
       "props": [
         {
-          "prop": "logos",
-          "type": "Logo[]",
+          "prop": "logoGroups",
+          "type": "React.ReactNode[][]",
           "defaultValue": "-",
-          "description": "Array of logo objects."
+          "description": "Required groups of logo nodes. Each inner array is animated within one grid column."
         },
         {
           "prop": "className",
@@ -3254,6 +3254,18 @@
           "type": "number",
           "defaultValue": "30",
           "description": "Duration of the animation cycle in seconds."
+        },
+        {
+          "prop": "stagger",
+          "type": "number",
+          "defaultValue": "0",
+          "description": "Animation timing offset between logo groups."
+        },
+        {
+          "prop": "logoWidth",
+          "type": "string",
+          "defaultValue": "'200px'",
+          "description": "Width of each logo group column."
         }
       ],
       "additionalPropSections": null

--- a/src/lib/component-docs.ts
+++ b/src/lib/component-docs.ts
@@ -1122,20 +1122,26 @@ export function LogoSliderDemo() {
     includeUtils: true,
     usageCode: `import { StackedLogos } from "@/components/ui/stacked-logos"
 
+const logoGroups = [
+  [
+    <img key="acme" src="/logos/acme.svg" alt="Acme" />,
+    <img key="globex" src="/logos/globex.svg" alt="Globex" />,
+  ],
+  [
+    <img key="initech" src="/logos/initech.svg" alt="Initech" />,
+    <img key="umbrella" src="/logos/umbrella.svg" alt="Umbrella" />,
+  ],
+]
+
 export function StackedLogosDemo() {
-  return (
-    <StackedLogos
-      logos={[
-        { src: "/logo1.svg", alt: "Logo 1" },
-        { src: "/logo2.svg", alt: "Logo 2" },
-      ]}
-    />
-  )
+  return <StackedLogos logoGroups={logoGroups} />
 }`,
     props: [
-      { prop: "logos", type: "Logo[]", defaultValue: "-", description: "Array of logo objects." },
+      { prop: "logoGroups", type: "React.ReactNode[][]", defaultValue: "-", description: "Required groups of logo nodes. Each inner array is animated within one grid column." },
       { prop: "className", type: "string", defaultValue: "-", description: "Additional CSS classes." },
       { prop: "duration", type: "number", defaultValue: "30", description: "Duration of the animation cycle in seconds." },
+      { prop: "stagger", type: "number", defaultValue: "0", description: "Animation timing offset between logo groups." },
+      { prop: "logoWidth", type: "string", defaultValue: "'200px'", description: "Width of each logo group column." },
     ],
   },
 


### PR DESCRIPTION
## Summary

- update the StackedLogos usage example to pass two-dimensional React node arrays through logoGroups
- align the props table with the complete component interface
- regenerate the MCP catalog so downstream docs consumers receive the corrected API

## Validation

- npx eslint src/lib/component-docs.ts
- npm --workspace packages/mcp run build
- npm run build
- served the production build and verified /components/stacked-logos returns 200, includes logoGroups and React.ReactNode[][], and excludes the stale Logo[] type

Closes #74

## Summary by Sourcery

Align StackedLogos documentation and generated catalog with the current logoGroups component interface.

Bug Fixes:
- Correct the StackedLogos documentation to use the current logoGroups API instead of the obsolete logos prop.

Enhancements:
- Complete the StackedLogos props documentation with stagger and logoWidth.
- Regenerate the MCP catalog with the corrected StackedLogos API documentation.

Documentation:
- Update the StackedLogos usage example and props table to reflect grouped React node logos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Stacked Logos example to support grouped logo content.
  * Documented new layout options for logo spacing and width.
  * Replaced the previous flat logo configuration with the grouped format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->