### PR TITLE
fix(registry): avoid site DNS for component installs

### DIFF
--- a/packages/cli/scripts/smoke.mjs
+++ b/packages/cli/scripts/smoke.mjs
@@ -116,7 +116,12 @@ await withTemp(async (dir) => {
   const claudeMd = await readFile(join(dir, "CLAUDE.md"), "utf8");
   assert(agents.includes("<!-- BEGIN:vengeance-ui -->"), "agents marker");
   assert(agents.includes("<!-- END:vengeance-ui -->"), "agents end marker");
-  assert(claudeMd.includes("vengenceui.com/r/{componentName}.json"), "install url");
+  assert(
+    claudeMd.includes(
+      "raw.githubusercontent.com/Ashutoshx7/VengeanceUI/main/public/r/{componentName}.json",
+    ),
+    "install url",
+  );
 
   const again = run(dir, ["init"]);
   assert(again.stdout.includes("✔  Agent skill"), "idempotent");

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -93,7 +93,7 @@ export async function runInit(opts: Options) {
 
   if (!opts.dryRun) {
     done(
-      "npx shadcn@latest add https://www.vengenceui.com/r/{name}.json",
+      "npx shadcn@latest add https://raw.githubusercontent.com/Ashutoshx7/VengeanceUI/main/public/r/{name}.json",
     );
   } else {
     console.log();

--- a/packages/cli/templates/instructions.md
+++ b/packages/cli/templates/instructions.md
@@ -5,5 +5,5 @@ Prefer VengeanceUI registry components over custom UI. Use the `vengeance-ui` sk
 Install via:
 
 ```bash
-npx shadcn@latest add https://www.vengenceui.com/r/{componentName}.json
+npx shadcn@latest add https://raw.githubusercontent.com/Ashutoshx7/VengeanceUI/main/public/r/{componentName}.json
 ```

--- a/packages/cli/templates/skill/install.md
+++ b/packages/cli/templates/skill/install.md
@@ -26,18 +26,18 @@ npx shadcn@latest init
 
 ## Add a component
 
-Registry base: `https://www.vengenceui.com/r`
+Registry base: `https://raw.githubusercontent.com/Ashutoshx7/VengeanceUI/main/public/r`
 
 ```bash
-npx shadcn@latest add https://www.vengenceui.com/r/{componentName}.json
+npx shadcn@latest add https://raw.githubusercontent.com/Ashutoshx7/VengeanceUI/main/public/r/{componentName}.json
 ```
 
 Examples:
 
 ```bash
-npx shadcn@latest add https://www.vengenceui.com/r/animated-button.json
-pnpm dlx shadcn@latest add https://www.vengenceui.com/r/gooey-text-reveal.json
-bunx shadcn@latest add https://www.vengenceui.com/r/spotlight-navbar.json
+npx shadcn@latest add https://raw.githubusercontent.com/Ashutoshx7/VengeanceUI/main/public/r/animated-button.json
+pnpm dlx shadcn@latest add https://raw.githubusercontent.com/Ashutoshx7/VengeanceUI/main/public/r/gooey-text-reveal.json
+bunx shadcn@latest add https://raw.githubusercontent.com/Ashutoshx7/VengeanceUI/main/public/r/spotlight-navbar.json
 ```
 
 Prefer MCP `get_install_command` so the package manager and **componentName** (not docs slug) are correct.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -69,8 +69,8 @@ For global `~/.cursor/mcp.json`, use an absolute path to `dist/index.js` instead
 | `list_categories`      | Marketing catalog categories                          |
 | `search_components`    | Search by name / slug / description / category        |
 | `get_component`        | Full docs entry (slug **or** `componentName`)         |
-| `get_install_command`  | `shadcn add https://www.vengenceui.com/r/{name}.json` |
-| `get_component_source` | Live registry JSON from the site                      |
+| `get_install_command`  | `shadcn add https://raw.githubusercontent.com/Ashutoshx7/VengeanceUI/main/public/r/{name}.json` |
+| `get_component_source` | Registry JSON from the repository                     |
 | `list_registry`        | All registry names (includes blocks)                  |
 
 ## Generate index

--- a/packages/mcp/data/index.json
+++ b/packages/mcp/data/index.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-08-20T21:34:05.621Z",
-  "registryBaseUrl": "https://www.vengenceui.com/r",
+  "generatedAt": "2026-08-30T21:50:01.809Z",
+  "registryBaseUrl": "https://raw.githubusercontent.com/Ashutoshx7/VengeanceUI/main/public/r",
   "categories": [
     {
       "name": "Buttons",

--- a/packages/mcp/scripts/generate-index.mjs
+++ b/packages/mcp/scripts/generate-index.mjs
@@ -159,7 +159,8 @@ function main() {
 
   const index = {
     generatedAt: new Date().toISOString(),
-    registryBaseUrl: "https://www.vengenceui.com/r",
+    registryBaseUrl:
+      "https://raw.githubusercontent.com/Ashutoshx7/VengeanceUI/main/public/r",
     categories: categories.map((c) => ({
       name: c.name,
       count: c.items.length,

--- a/packages/mcp/src/smoke.ts
+++ b/packages/mcp/src/smoke.ts
@@ -42,7 +42,7 @@ assert(
 );
 assert(
   install ===
-    "npx shadcn@latest add https://www.vengenceui.com/r/animated-button.json",
+    "npx shadcn@latest add https://raw.githubusercontent.com/Ashutoshx7/VengeanceUI/main/public/r/animated-button.json",
   `unexpected install command: ${install}`,
 );
 

--- a/src/app/docs/cli/page.tsx
+++ b/src/app/docs/cli/page.tsx
@@ -89,10 +89,10 @@ Options:
         </DocsParagraph>
         <PackageCommand
           commands={{
-            npm: "npx shadcn@latest add https://www.vengenceui.com/r/animated-rays.json -c ./apps/web",
-            pnpm: "pnpm dlx shadcn@latest add https://www.vengenceui.com/r/animated-rays.json -c ./apps/web",
-            yarn: "yarn dlx shadcn@latest add https://www.vengenceui.com/r/animated-rays.json -c ./apps/web",
-            bun: "bunx shadcn@latest add https://www.vengenceui.com/r/animated-rays.json -c ./apps/web",
+            npm: `${addAnimatedRaysCommand} -c ./apps/web`,
+            pnpm: `${addAnimatedRaysCommand.replace(/^npx/, "pnpm dlx")} -c ./apps/web`,
+            yarn: `${addAnimatedRaysCommand.replace(/^npx/, "yarn dlx")} -c ./apps/web`,
+            bun: `${addAnimatedRaysCommand.replace(/^npx/, "bunx")} -c ./apps/web`,
           }}
         />
       </DocsSection>
@@ -106,7 +106,7 @@ Options:
           title="components.json"
           code={`{
   "registries": {
-    "@vengeanceui": "https://www.vengenceui.com/r/{name}.json"
+    "@vengeanceui": "https://raw.githubusercontent.com/Ashutoshx7/VengeanceUI/main/public/r/{name}.json"
   }
 }`}
         />

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -1,6 +1,9 @@
 export type PackageManager = "npm" | "pnpm" | "bun" | "yarn";
 
-export const REGISTRY_BASE_URL = "https://www.vengenceui.com/r";
+// Keep component installation independent of the documentation site's DNS.
+// GitHub serves the same versioned files committed under public/r.
+export const REGISTRY_BASE_URL =
+  "https://raw.githubusercontent.com/Ashutoshx7/VengeanceUI/main/public/r";
 
 export const PACKAGE_MANAGER_EXECUTORS: Record<PackageManager, string> = {
   npm: "npx",


### PR DESCRIPTION
## Summary

- serve generated shadcn install commands from the repository-backed raw GitHub registry
- update website CLI docs, namespaced registry examples, CLI templates, and MCP data consistently
- add regression assertions that prevent the documentation-site hostname from returning to generated commands

## Verification

- `npm run smoke --workspace=vengeanceui`
- `npm run smoke --workspace=vengeanceui-mcp`
- scoped ESLint on all changed source files (no errors)
- `npm run build`
- clean Next.js project initialized with shadcn 4.19.0
- installed `stagger-text` through the replacement registry URL
- built the clean consumer project successfully
- rendered `/components/stagger-text` and `/docs/cli` in headless Chrome
- validated all 132 registry entries and referenced JSON files

Fixes #78

## Summary by Sourcery

Use the repository-backed raw GitHub registry for component installations across the CLI, MCP tooling, and documentation.

Bug Fixes:
- Serve generated component installation commands from the repository-backed raw GitHub registry instead of the documentation-site hostname.

Enhancements:
- Synchronize registry URLs across CLI output, templates, MCP metadata, and website documentation.
- Keep registry-backed component installation independent of documentation-site DNS availability.

Documentation:
- Update CLI documentation and namespaced registry examples to use the repository-backed registry URL.

Tests:
- Add regression assertions ensuring generated installation commands do not use the documentation-site hostname.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Component installation commands now use the GitHub-hosted registry URL.
  * CLI instructions, documentation, MCP metadata, and registry references have been updated to reflect the new installation source.
  * Documentation commands now use the configured registry consistently across package managers.

* **Bug Fixes**
  * Updated validation checks to confirm generated installation commands use the correct registry URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->